### PR TITLE
Add client credentials to supported grants

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -222,7 +222,12 @@ func newServer(ctx context.Context, c Config, rotationStrategy rotationStrategy)
 		supportedRes[respType] = true
 	}
 
-	supportedGrant := []string{grantTypeAuthorizationCode, grantTypeRefreshToken, grantTypeDeviceCode} // default
+	supportedGrant := []string{
+		grantTypeAuthorizationCode,
+		grantTypeRefreshToken,
+		grantTypeDeviceCode,
+		grantTypeClientCredentials,
+	} // default
 	if c.PasswordConnector != "" {
 		supportedGrant = append(supportedGrant, grantTypePassword)
 	}


### PR DESCRIPTION
This will cause the client_credentials grant to show up in the supported grant list which was missed in the previous change.