### PR TITLE
Add client name to token for client credentials

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1044,7 +1044,10 @@ func (s *Server) handleClientCredentialsGrant(w http.ResponseWriter, r *http.Req
 	nonce := q.Get("nonce")
 	scopes := strings.Fields(q.Get("scope"))
 
-	claims := storage.Claims{UserID: client.ID}
+	claims := storage.Claims{
+		UserID:   client.ID,
+		Username: client.Name,
+	}
 
 	accessToken, err := s.newAccessToken(client.ID, claims, scopes, nonce, "client")
 	if err != nil {


### PR DESCRIPTION
Currently the name field is empty, which makes it difficult for consumers to related it back to a specific client.  Specifying the Username field in the Claims object will cause the 'name' field in the ID and access tokens to be populated with the associated value.
