### PR TITLE
Increase GC window size to 10000

### DIFF
--- a/storage/kubernetes/storage.go
+++ b/storage/kubernetes/storage.go
@@ -41,7 +41,7 @@ const (
 )
 
 const (
-	gcResultLimit = 500
+	gcResultLimit = 10000
 )
 
 // Config values for the Kubernetes storage type.


### PR DESCRIPTION
This is an imperfect fix that will mitigate current issues around GC leakage, but needs a more robust solution.  If none of the first 500 objects returned is GCable, we'll potentially leak K8S resources until a point where we can never realistically catch up.  This will keep our window size within an acceptable range while also increasing the odds that we'll actually GC something.