### PR TITLE
deviceflow: ignore client secret for public clients

### DIFF
--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -331,7 +331,7 @@ func (s *Server) handleDeviceCallback(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		if client.Secret != deviceReq.ClientSecret {
+		if !client.Public && client.Secret != deviceReq.ClientSecret {
 			s.tokenErrHelper(w, errInvalidClient, "Invalid client credentials.", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
RFC8628 section 3.1[1] mandates that client secrets cannot be passed to the device authorization endpoint, meaning that dex is doing the wrong thing by checking them.

By definition, it does not really make sense for confidential (i.e. non-public) clients to use the device flow, as there are more appropriate flow for their use case. CLI and other applications where the device flow make sense cannot hide the client id & secret that they have to access or embed somewhere, making clients impossible to stay confidential.

Therefore, this commit removes the client secret comparison in the device flow for public clients. I left the logic intact for confidential clients as it would most likely break some of the assumptions we have, but a real fix should likely make the entire check go away with a feature flag.

I am waiting on more information from the upstream maintainers of dex before doing anything better than this though. For now, this fix is sufficient for our own needs.

[1]: https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
