### PR TITLE
Pass connector_id to /auth on completion of device auth flow

### DIFF
--- a/server/deviceflowhandlers.go
+++ b/server/deviceflowhandlers.go
@@ -407,6 +407,7 @@ func (s *Server) verifyUserCode(w http.ResponseWriter, r *http.Request) {
 		}
 
 		userCode = strings.ToUpper(userCode)
+		connectorID := r.Form.Get("connector_id")
 
 		// Find the user code in the available requests
 		deviceRequest, err := s.storage.GetDeviceRequest(userCode)
@@ -435,6 +436,9 @@ func (s *Server) verifyUserCode(w http.ResponseWriter, r *http.Request) {
 		q.Set("response_type", "code")
 		q.Set("redirect_uri", "/device/callback")
 		q.Set("scope", strings.Join(deviceRequest.Scopes, " "))
+		if connectorID != "" {
+			q.Set("connector_id", connectorID)
+		}
 		u.RawQuery = q.Encode()
 
 		http.Redirect(w, r, u.String(), http.StatusFound)

--- a/server/templates.go
+++ b/server/templates.go
@@ -266,11 +266,12 @@ func (t *templates) device(r *http.Request, w http.ResponseWriter, postURL strin
 		w.WriteHeader(http.StatusBadRequest)
 	}
 	data := struct {
-		PostURL  string
-		UserCode string
-		Invalid  bool
-		ReqPath  string
-	}{postURL, userCode, lastWasInvalid, r.URL.Path}
+		PostURL     string
+		UserCode    string
+		Invalid     bool
+		ReqPath     string
+		ConnectorID string
+	}{postURL, userCode, lastWasInvalid, r.URL.Path, r.URL.Query().Get("connector_id")}
 	return renderTemplate(w, t.deviceTmpl, data)
 }
 

--- a/web/templates/device.html
+++ b/web/templates/device.html
@@ -9,6 +9,7 @@
       {{ else }}
       <input tabindex="2" required id="user_code" name="user_code" type="text" class="theme-form-input" placeholder="XXXX-XXXX" autocomplete="off"  {{ if .Invalid }} autofocus {{ end }}/>
       {{ end }}
+      <input type="hidden" name="connector_id" value="{{.ConnectorID}}" />
     </div>
 
     {{ if .Invalid }}


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
This allows users to select a connector when initiating device auth. They simply need to append "connector_id" to the query string of "/device"  alongside "user_code". The form will submit the chosen connector to Dex which will add the connector to  "/auth". If a connector is passed to "/auth", Dex will select it automatically.

#### What this PR does / why we need it

To skip the webpage for selecting a connector so users don't have to click on the UI.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
