### PR TITLE
Disable submit button when submitting device code

### DIFF
--- a/web/templates/device.html
+++ b/web/templates/device.html
@@ -21,10 +21,18 @@
   </form>
 </div>
 
-{{ if and .UserCode (not .Invalid) }}
 <script>
-  document.querySelector("form[method=''post'']")?.submit();
+  const form = document.querySelector("form[method=''post'']");
+
+  form.addEventListener("submit", function() {
+    const submitButton = document.getElementById("submit-login");
+    submitButton.disabled = true;
+    submitButton.innerText = "Submitting...";
+  });
+
+  {{ if and .UserCode (not .Invalid) }}
+  form.requestSubmit();
+  {{ end }}
 </script>
-{{ end }}
 
 {{ template "footer.html" . }}


### PR DESCRIPTION
## Overview

- The POST request can take a few seconds and the browser tab spinning icon is the only way to tell it's pending.
- requestSubmit() fires the submit event, unlike submit(). This lets a single event listener disable the button on both the auto-submit and manual paths. 
- The form is always present, so I've removed the ? on the method call.

## Testing

Outside of production, the POST request will be too fast. In Firefox's network tab, you can throttle network speeds to simulate a longer loading time. Entering a code manually or via the query string auto-submission should both display the loading button.